### PR TITLE
Fix page transitions

### DIFF
--- a/imports/ui/stylesheets/modules/_maincontent.scss
+++ b/imports/ui/stylesheets/modules/_maincontent.scss
@@ -10,31 +10,26 @@ main {
   justify-content: flex-start;
   align-items: center;
   flex-grow: 1;
+  position: relative;
 }
 
-.main-view-enter {
-  opacity: 0;
-  animation: slideIn 1s;
-}
+.main-wrapper{
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
 
-.main-view-enter .main-view-enter-active {
-  opacity: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .main-view-leave {
-  opacity: 1;
-  animation: slideOut 1s cubic-bezier(.55,0,.1,1);
-}
-
-.main-view-leave .main-view-leave-active {
   opacity: 0;
-  transition: all 0.3s;
+  animation: slideOut 0.3s cubic-bezier(.55,0,.1,1);
 }
-.main-view-appear {
+.main-view-appear, .main-view-enter{
   opacity: 0;
   animation: slideDown 1s cubic-bezier(.55,0,.1,1);
-}
-
-.main-view-appear .main-view-appear-active {
-  opacity: 1;
 }

--- a/imports/ui/user/MainView.jsx
+++ b/imports/ui/user/MainView.jsx
@@ -15,31 +15,15 @@ export default class MainView extends Component {
     switch (this.props.appstate) {
       case 'login':
         return (
-          <ReactCSSTransitionGroup
-          transitionName="main-view"
-          component="main"
-          transitionAppear={true}
-          transitionAppearTimeout={1000}
-          transitionEnterTimeout={1000}
-          transitionLeaveTimeout={1000}>
-            <LoginForm key={ '' + Math.random() }/>
-          </ReactCSSTransitionGroup>
+          <LoginForm/>
         );
       break;
       case 'waiting':
         return (
-          <ReactCSSTransitionGroup
-          transitionName="main-view"
-          component="main"
-          transitionAppear={true}
-          transitionAppearTimeout={1000}
-          transitionEnterTimeout={1000}
-          transitionLeaveTimeout={1000}>
-            <div className="waiting" key={ '' + Math.random() }>
-              <WaitingMessage />
-              <DisplayUserInformation name="Marc Nitzsche" rank={ 12 } from={ 100 } />
-            </div>
-          </ReactCSSTransitionGroup>
+          <div className="waiting">
+            <WaitingMessage />
+            <DisplayUserInformation name="Marc Nitzsche" rank={ 12 } from={ 100 } />
+          </div>
         );
       break;
       case 'active':
@@ -52,7 +36,19 @@ export default class MainView extends Component {
   };
 
   render() {
-    return this.displayMain();
+    return (
+        <ReactCSSTransitionGroup
+        transitionName="main-view"
+        component="main"
+        transitionAppear={true}
+        transitionAppearTimeout={1000}
+        transitionEnterTimeout={1000}
+        transitionLeaveTimeout={1000}>
+          <div className='main-wrapper' key={ '' + Math.random() }>
+            {this.displayMain()}
+          </div>
+      </ReactCSSTransitionGroup>
+    )
   }
 }
 


### PR DESCRIPTION
Das eigentliche Problem war in der CSS, ich hab diese *-active states gekillt. Hab es etwas verkompliziert. Hat kein unterschied gemacht die ReactCSSTransitionGroup um wieder um alle Elemente zu wrappen. Bei mir funktioniert es ganz gut. hab die leave animation mit absicht etwas verkürzt aber ich denke damit kann man noch viel rumspielen.